### PR TITLE
Feat/#4 mvptest 도메인 crud구현

### DIFF
--- a/src/main/kotlin/com/team1/mvp_test/common/error/CategoryErrorMessage.kt
+++ b/src/main/kotlin/com/team1/mvp_test/common/error/CategoryErrorMessage.kt
@@ -1,0 +1,5 @@
+package com.team1.mvp_test.common.error
+
+enum class CategoryErrorMessage(val message: String) {
+    DOSE_NOT_EXIST("존재하지 않는 카테고리입니다.")
+}

--- a/src/main/kotlin/com/team1/mvp_test/common/error/CategoryErrorMessage.kt
+++ b/src/main/kotlin/com/team1/mvp_test/common/error/CategoryErrorMessage.kt
@@ -1,5 +1,5 @@
 package com.team1.mvp_test.common.error
 
 enum class CategoryErrorMessage(val message: String) {
-    DOSE_NOT_EXIST("존재하지 않는 카테고리입니다.")
+    NOT_EXIST("존재하지 않는 카테고리입니다.")
 }

--- a/src/main/kotlin/com/team1/mvp_test/common/error/EnterpriseErrorMessage.kt
+++ b/src/main/kotlin/com/team1/mvp_test/common/error/EnterpriseErrorMessage.kt
@@ -1,5 +1,6 @@
 package com.team1.mvp_test.common.error
 
 enum class EnterpriseErrorMessage(val message: String) {
-    ALREADY_EXISTS("이미 존재하는 기업입니다")
+    ALREADY_EXISTS("이미 존재하는 기업입니다."),
+    NOT_AUTHORISED("테스트 작성자가 아닙니다.")
 }

--- a/src/main/kotlin/com/team1/mvp_test/common/error/EnterpriseErrorMessage.kt
+++ b/src/main/kotlin/com/team1/mvp_test/common/error/EnterpriseErrorMessage.kt
@@ -2,5 +2,5 @@ package com.team1.mvp_test.common.error
 
 enum class EnterpriseErrorMessage(val message: String) {
     ALREADY_EXISTS("이미 존재하는 기업입니다."),
-    NOT_AUTHORISED("테스트 작성자가 아닙니다.")
+    NOT_AUTHORIZED("테스트 작성자가 아닙니다.")
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/constant/RecruitType.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/constant/RecruitType.kt
@@ -1,0 +1,16 @@
+package com.team1.mvp_test.domain.mvptest.constant
+
+enum class RecruitType {
+    FIRST_COME, DIRECT_SELECT;
+
+    companion object {
+        fun fromString(str : String): RecruitType {
+            return runCatching {
+                RecruitType.valueOf(str.uppercase())
+            }.getOrElse { throw IllegalArgumentException("$str can't be recruit type.") }
+        }
+    }
+}
+
+
+

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
@@ -1,6 +1,7 @@
 package com.team1.mvp_test.domain.mvptest.controller
 
-import com.team1.mvp_test.domain.mvptest.dto.mvptest.CreateMpvTestRequest
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.CreateCategoryRequest
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.CreateMvpTestRequest
 import com.team1.mvp_test.domain.mvptest.dto.mvptest.MvpTestListResponse
 import com.team1.mvp_test.domain.mvptest.dto.mvptest.MvpTestResponse
 import com.team1.mvp_test.domain.mvptest.dto.mvptest.UpdateMvpTestRequest
@@ -28,7 +29,7 @@ class MvpTestController(
     @PostMapping("")
     @PreAuthorize("hasRole('ENTERPRISE')")
     fun createMvpTest(
-        @RequestBody request: CreateMpvTestRequest,
+        @RequestBody request: CreateMvpTestRequest,
         @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<MvpTestResponse> {
         return ResponseEntity
@@ -74,5 +75,15 @@ class MvpTestController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(mvpTestService.getMvpTestList())
+    }
+
+    @PostMapping("/category")
+    //@PreAuthorize("hasRole('ADMIN')")
+    fun createCategory(
+        @RequestBody request: CreateCategoryRequest
+    ): ResponseEntity<String> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(mvpTestService.createCategory(request))
     }
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
@@ -1,10 +1,16 @@
 package com.team1.mvp_test.domain.mvptest.controller
 
 import com.team1.mvp_test.domain.mvptest.dto.mvptest.CreateMpvTestRequest
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.MvpTestListResponse
 import com.team1.mvp_test.domain.mvptest.dto.mvptest.MvpTestResponse
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.UpdateMvpTestRequest
 import com.team1.mvp_test.domain.mvptest.service.MvpTestService
+import com.team1.mvp_test.infra.security.UserPrincipal
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,44 +20,48 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("")
+@RequestMapping("/mvp_tests")
 class MvpTestController(
     private val mvpTestService: MvpTestService
 ) {
 
-    @PostMapping("/mvp_tests")
+    @PostMapping("")
+    @PreAuthorize("hasRole('ENTERPRISE')")
     fun createMvpTest(
-        @RequestBody request: CreateMpvTestRequest
+        @RequestBody request: CreateMpvTestRequest,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<MvpTestResponse> {
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .body(mvpTestService.createMvpTest(request))
+            .body(mvpTestService.createMvpTest(userPrincipal.id, request))
     }
 
-
     @PutMapping("/{testId}")
+    @PreAuthorize("hasRole('ENTERPRISE')")
     fun updateMvpTest(
         @RequestBody request: UpdateMvpTestRequest,
-        @PathVariable("testId") testId: Long
-    ): ResponseEntity<MvpTestResponse>{
+        @PathVariable("testId") testId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<MvpTestResponse> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(mvpTestService.updateMvpTest())
+            .body(mvpTestService.updateMvpTest(userPrincipal.id, testId, request))
     }
 
     @DeleteMapping("/{testId}")
+    @PreAuthorize("hasRole('ENTERPRISE')")
     fun deleteMvpTest(
-        @PathVariable ("testId") testId: Long,
+        @PathVariable("testId") testId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<Unit> {
-        mvpTestService.deleteMvpTest(testId)
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)
-            .build()
+            .body(mvpTestService.deleteMvpTest(userPrincipal.id, testId))
     }
 
     @GetMapping("/{testId}")
     fun getMvpTest(
-        @PathVariable ("testId") testId: Long,
+        @PathVariable("testId") testId: Long,
     ): ResponseEntity<MvpTestResponse> {
         return ResponseEntity
             .status(HttpStatus.OK)
@@ -65,5 +75,4 @@ class MvpTestController(
             .status(HttpStatus.OK)
             .body(mvpTestService.getMvpTestList())
     }
-
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
@@ -1,0 +1,69 @@
+package com.team1.mvp_test.domain.mvptest.controller
+
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.CreateMpvTestRequest
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.MvpTestResponse
+import com.team1.mvp_test.domain.mvptest.service.MvpTestService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("")
+class MvpTestController(
+    private val mvpTestService: MvpTestService
+) {
+
+    @PostMapping("/mvp_tests")
+    fun createMvpTest(
+        @RequestBody request: CreateMpvTestRequest
+    ): ResponseEntity<MvpTestResponse> {
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(mvpTestService.createMvpTest(request))
+    }
+
+
+    @PutMapping("/{testId}")
+    fun updateMvpTest(
+        @RequestBody request: UpdateMvpTestRequest,
+        @PathVariable("testId") testId: Long
+    ): ResponseEntity<MvpTestResponse>{
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(mvpTestService.updateMvpTest())
+    }
+
+    @DeleteMapping("/{testId}")
+    fun deleteMvpTest(
+        @PathVariable ("testId") testId: Long,
+    ): ResponseEntity<Unit> {
+        mvpTestService.deleteMvpTest(testId)
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build()
+    }
+
+    @GetMapping("/{testId}")
+    fun getMvpTest(
+        @PathVariable ("testId") testId: Long,
+    ): ResponseEntity<MvpTestResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(mvpTestService.getMvpTest(testId))
+    }
+
+    @GetMapping("")
+    fun getMvpTestList(
+    ): ResponseEntity<MvpTestListResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(mvpTestService.getMvpTestList())
+    }
+
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/CreateCategoryRequest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/CreateCategoryRequest.kt
@@ -1,0 +1,5 @@
+package com.team1.mvp_test.domain.mvptest.dto.mvptest
+
+data class CreateCategoryRequest(
+    val category : String = ""
+)

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/CreateMpvTestRequest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/CreateMpvTestRequest.kt
@@ -1,0 +1,21 @@
+package com.team1.mvp_test.domain.mvptest.dto.mvptest
+
+import java.time.LocalDateTime
+
+data class CreateMpvTestRequest(
+        val mvpName : String,
+        val mvpType : String,
+        val recruitStartDate : LocalDateTime,
+        val recruitEndDate : LocalDateTime,
+        val testStartDate : LocalDateTime,
+        val testEndDate : LocalDateTime,
+        val mainImageUrl : String,
+        val mvpInfo : String,
+        val rewardBudget : Int,
+        val requirementMinAge : Int?,
+        val requirementMaxAge : Int?,
+        val requirementSex : Boolean,
+        val recruitType : String,
+        val recruitNum : Long,
+        val category : List<String>
+)

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/CreateMpvTestRequest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/CreateMpvTestRequest.kt
@@ -1,21 +1,43 @@
 package com.team1.mvp_test.domain.mvptest.dto.mvptest
 
+import com.team1.mvp_test.domain.mvptest.constant.RecruitType
+import com.team1.mvp_test.domain.mvptest.model.MvpTest
 import java.time.LocalDateTime
 
 data class CreateMpvTestRequest(
-        val mvpName : String,
-        val mvpType : String,
-        val recruitStartDate : LocalDateTime,
-        val recruitEndDate : LocalDateTime,
-        val testStartDate : LocalDateTime,
-        val testEndDate : LocalDateTime,
-        val mainImageUrl : String,
-        val mvpInfo : String,
-        val rewardBudget : Int,
-        val requirementMinAge : Int?,
-        val requirementMaxAge : Int?,
-        val requirementSex : Boolean,
-        val recruitType : String,
-        val recruitNum : Long,
-        val category : List<String>
-)
+    val mvpName: String,
+    val recruitStartDate: LocalDateTime,
+    val recruitEndDate: LocalDateTime,
+    val testStartDate: LocalDateTime,
+    val testEndDate: LocalDateTime,
+    val mainImageUrl: String,
+    val mvpInfo: String,
+    val mvpUrl: String,
+    val rewardBudget: Int,
+    val requirementMinAge: Int?,
+    val requirementMaxAge: Int?,
+    val requirementSex: Boolean?,
+    val recruitType: String,
+    val recruitNum: Long,
+    val category: List<String>
+) {
+    fun toMvpTest(enterpriseId: Long): MvpTest {
+        return MvpTest(
+            enterpriseId = enterpriseId,
+            mvpName = mvpName,
+            recruitStartDate = recruitStartDate,
+            recruitEndDate = recruitEndDate,
+            testStartDate = testStartDate,
+            testEndDate = testEndDate,
+            mainImageUrl = mainImageUrl,
+            mvpInfo = mvpInfo,
+            mvpUrl = mvpUrl,
+            rewardBudget = rewardBudget,
+            requirementMinAge = requirementMinAge,
+            requirementMaxAge = requirementMaxAge,
+            requirementSex = requirementSex,
+            recruitType = RecruitType.fromString(recruitType),
+            recruitNum = recruitNum
+        )
+    }
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/CreateMvpTestRequest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/CreateMvpTestRequest.kt
@@ -4,7 +4,7 @@ import com.team1.mvp_test.domain.mvptest.constant.RecruitType
 import com.team1.mvp_test.domain.mvptest.model.MvpTest
 import java.time.LocalDateTime
 
-data class CreateMpvTestRequest(
+data class CreateMvpTestRequest(
     val mvpName: String,
     val recruitStartDate: LocalDateTime,
     val recruitEndDate: LocalDateTime,
@@ -37,7 +37,8 @@ data class CreateMpvTestRequest(
             requirementMaxAge = requirementMaxAge,
             requirementSex = requirementSex,
             recruitType = RecruitType.fromString(recruitType),
-            recruitNum = recruitNum
+            recruitNum = recruitNum,
+            categories = null
         )
     }
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestListResponse.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestListResponse.kt
@@ -1,0 +1,5 @@
+package com.team1.mvp_test.domain.mvptest.dto.mvptest
+
+data class MvpTestListResponse(
+
+)

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestListResponse.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestListResponse.kt
@@ -1,5 +1,5 @@
 package com.team1.mvp_test.domain.mvptest.dto.mvptest
 
 data class MvpTestListResponse(
-
+    val mvpTestList : List<MvpTestResponse>
 )

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestResponse.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestResponse.kt
@@ -1,0 +1,4 @@
+package com.team1.mvp_test.domain.mvptest.dto.mvptest
+
+class MvpTestResponse {
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestResponse.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestResponse.kt
@@ -1,4 +1,49 @@
 package com.team1.mvp_test.domain.mvptest.dto.mvptest
 
-class MvpTestResponse {
+import com.team1.mvp_test.domain.mvptest.model.MvpTest
+import java.time.LocalDateTime
+
+data class MvpTestResponse(
+    val id: Long?,
+    val enterpriseId: Long?,
+    val mvpName: String,
+    val recruitStartDate: LocalDateTime,
+    val recruitEndDate: LocalDateTime,
+    val testStartDate: LocalDateTime,
+    val testEndDate: LocalDateTime,
+    val mainImageUrl: String,
+    val mvpInfo: String,
+    val mvpUrl: String,
+    val rewardBudget: Int,
+    val requirementMinAge: Int?,
+    val requirementMaxAge: Int?,
+    val requirementSex: Boolean?,
+    val recruitType: String,
+    val recruitNum: Long,
+    val category: List<String>
+) {
+    companion object {
+        fun from(mvpTest: MvpTest): MvpTestResponse {
+            return MvpTestResponse(
+                id = mvpTest.id,
+                enterpriseId = mvpTest.id,
+                mvpName = mvpTest.mvpName,
+                recruitStartDate = mvpTest.recruitStartDate,
+                recruitEndDate = mvpTest.recruitEndDate,
+                testStartDate = mvpTest.testStartDate,
+                testEndDate = mvpTest.testEndDate,
+                mainImageUrl = mvpTest.mainImageUrl,
+                mvpInfo = mvpTest.mvpInfo,
+                mvpUrl = mvpTest.mvpUrl,
+                rewardBudget = mvpTest.rewardBudget,
+                requirementMinAge = mvpTest.requirementMinAge,
+                requirementMaxAge = mvpTest.requirementMaxAge,
+                requirementSex = mvpTest.requirementSex,
+                recruitType = mvpTest.recruitType.toString(),
+                recruitNum = mvpTest.recruitNum,
+                category = mvpTest.categories.map { it.category.name }
+            )
+
+        }
+    }
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestResponse.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/MvpTestResponse.kt
@@ -20,13 +20,13 @@ data class MvpTestResponse(
     val requirementSex: Boolean?,
     val recruitType: String,
     val recruitNum: Long,
-    val category: List<String>
+    val category: List<String>?
 ) {
     companion object {
         fun from(mvpTest: MvpTest): MvpTestResponse {
             return MvpTestResponse(
                 id = mvpTest.id,
-                enterpriseId = mvpTest.id,
+                enterpriseId = mvpTest.enterpriseId,
                 mvpName = mvpTest.mvpName,
                 recruitStartDate = mvpTest.recruitStartDate,
                 recruitEndDate = mvpTest.recruitEndDate,
@@ -41,7 +41,7 @@ data class MvpTestResponse(
                 requirementSex = mvpTest.requirementSex,
                 recruitType = mvpTest.recruitType.toString(),
                 recruitNum = mvpTest.recruitNum,
-                category = mvpTest.categories.map { it.category.name }
+                category = mvpTest.categories?.map { it.category.name }
             )
 
         }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/UpdateMvpTestRequest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/UpdateMvpTestRequest.kt
@@ -1,5 +1,21 @@
 package com.team1.mvp_test.domain.mvptest.dto.mvptest
 
-data class UpdateMvpTestRequest(
+import java.time.LocalDateTime
 
+data class UpdateMvpTestRequest(
+    val mvpName : String,
+    val recruitStartDate : LocalDateTime,
+    val recruitEndDate : LocalDateTime,
+    val testStartDate : LocalDateTime,
+    val testEndDate : LocalDateTime,
+    val mainImageUrl : String,
+    val mvpInfo : String,
+    val mvpUrl: String,
+    val rewardBudget : Int,
+    val requirementMinAge : Int?,
+    val requirementMaxAge : Int?,
+    val requirementSex : Boolean,
+    val recruitType : String,
+    val recruitNum : Long,
+    val category : List<String>
 )

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/UpdateMvpTestRequest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/mvptest/UpdateMvpTestRequest.kt
@@ -1,0 +1,5 @@
+package com.team1.mvp_test.domain.mvptest.dto.mvptest
+
+data class UpdateMvpTestRequest(
+
+)

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/Category.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/Category.kt
@@ -1,0 +1,21 @@
+package com.team1.mvp_test.domain.mvptest.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Table(name = "category")
+@Entity
+class Category(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "name")
+    val name: String
+) {
+
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/CategoryMap.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/CategoryMap.kt
@@ -1,0 +1,23 @@
+package com.team1.mvp_test.domain.mvptest.model
+
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
+import jakarta.persistence.Table
+
+@Table(name = "category_map")
+@Entity
+class CategoryMap(
+    @EmbeddedId
+    val id: CategoryMapId,
+
+    @ManyToOne
+    @MapsId("categoryId")
+    @JoinColumn(name = "category_id")
+    val category: Category
+
+) {
+
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/CategoryMapId.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/CategoryMapId.kt
@@ -1,0 +1,29 @@
+package com.team1.mvp_test.domain.mvptest.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+
+@Embeddable
+class CategoryMapId(
+    @Column(name = "category_id")
+    val categoryId: Long?,
+
+    @Column(name = "mvp_test_id")
+    val mvpTestId: Long?
+) : Serializable {
+    // Default constructor for JPA
+    constructor() : this(0L, 0L)
+
+    // Equals and hashCode methods should be overridden for composite keys
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || javaClass != other.javaClass) return false
+        val that = other as CategoryMapId
+        return categoryId == that.categoryId && mvpTestId == that.mvpTestId
+    }
+
+    override fun hashCode(): Int {
+        return 31 * categoryId.hashCode() + mvpTestId.hashCode()
+    }
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/MvpTest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/MvpTest.kt
@@ -65,6 +65,9 @@ class MvpTest(
     @Column(name = "recruit_num")
     var recruitNum : Long,
 
+    @OneToMany
+    var categories : List<CategoryMap>?
+
     ) {
 
     @Column(name = "state")
@@ -73,8 +76,7 @@ class MvpTest(
     @Column(name = "reject_reason")
     lateinit var rejectReason : String
 
-    @OneToMany
-    lateinit var categories : List<CategoryMap>
+
 
 
 

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/MvpTest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/MvpTest.kt
@@ -1,0 +1,67 @@
+package com.team1.mvp_test.domain.mvptest.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Table(name = "mvp_test")
+@Entity
+class MvpTest(
+    @Id
+    @GeneratedValue()
+    val id: Long? = null,
+
+    @Column(name = "mvp_name")
+    var mvpName: String,
+
+    @Column(name = "recruit_start_date")
+    var recruitStartDate: LocalDateTime,
+
+    @Column(name = "recruit_ent_date")
+    var recruitEndDate: LocalDateTime,
+
+    @Column(name = "test_start_date")
+    var testStartDate: LocalDateTime,
+
+    @Column(name = "test_end_date")
+    var testEndDate : LocalDateTime,
+
+    @Column(name= "main_image_url")
+    var mainImageUrl : String,
+
+    @Column(name = "mvp_info" )
+    var mvpInfo :String,
+
+    @Column(name = "mvp_url")
+    var mvpUrl : String,
+
+    @Column(name = "reword_budget")
+    var rewardBudget : Int,
+
+    @Column(name = "requirement_min_age")
+    var requirementMinAge : Int?,
+
+    @Column(name = "requirement_max_age")
+    var requirementMaxAge : Int?,
+
+    @Column(name = "requriement_sex")
+    var requirementSex : Boolean,
+
+    @Column(name = "recruit_type")
+    var recruitType : String,
+
+    @Column(name = "recruit_num")
+    var recruitNum : Long,
+
+    @Column(name = "state")
+    var state : String,
+
+    @Column(name = "reject_reason")
+    var rejectReason : String
+
+    ) {
+
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/MvpTest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/model/MvpTest.kt
@@ -1,9 +1,15 @@
 package com.team1.mvp_test.domain.mvptest.model
 
+import com.team1.mvp_test.domain.enterprise.model.Enterprise
+import com.team1.mvp_test.domain.mvptest.constant.RecruitType
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.UpdateMvpTestRequest
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import java.time.LocalDateTime
 
@@ -11,8 +17,11 @@ import java.time.LocalDateTime
 @Entity
 class MvpTest(
     @Id
-    @GeneratedValue()
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
+
+    @Column(name = "enterprise_id")
+    val enterpriseId : Long,
 
     @Column(name = "mvp_name")
     var mvpName: String,
@@ -47,21 +56,43 @@ class MvpTest(
     @Column(name = "requirement_max_age")
     var requirementMaxAge : Int?,
 
-    @Column(name = "requriement_sex")
-    var requirementSex : Boolean,
+    @Column(name = "requirement_sex")
+    var requirementSex : Boolean?,
 
     @Column(name = "recruit_type")
-    var recruitType : String,
+    var recruitType : RecruitType,
 
     @Column(name = "recruit_num")
     var recruitNum : Long,
 
-    @Column(name = "state")
-    var state : String,
-
-    @Column(name = "reject_reason")
-    var rejectReason : String
-
     ) {
 
+    @Column(name = "state")
+    lateinit var state : String
+
+    @Column(name = "reject_reason")
+    lateinit var rejectReason : String
+
+    @OneToMany
+    lateinit var categories : List<CategoryMap>
+
+
+
+    fun update(request: UpdateMvpTestRequest, categoryMaps: List<CategoryMap>){
+        mvpName = request.mvpName
+        recruitStartDate = request.recruitStartDate
+        recruitEndDate = request.recruitEndDate
+        testStartDate = request.testStartDate
+        testEndDate = request.testEndDate
+        mainImageUrl = request.mainImageUrl
+        mvpInfo = request.mvpInfo
+        mvpUrl = request.mvpUrl
+        rewardBudget = request.rewardBudget
+        requirementMinAge = request.requirementMinAge
+        requirementMaxAge = request.requirementMaxAge
+        requirementSex = request.requirementSex
+        recruitType = RecruitType.fromString(request.recruitType)
+        recruitNum = request.recruitNum
+        categories = categoryMaps
+    }
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/CategoryMapRepository.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/CategoryMapRepository.kt
@@ -1,0 +1,8 @@
+package com.team1.mvp_test.domain.mvptest.repository
+
+import com.team1.mvp_test.domain.mvptest.model.CategoryMap
+import com.team1.mvp_test.domain.mvptest.model.CategoryMapId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CategoryMapRepository: JpaRepository<CategoryMap, CategoryMapId> {
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/CategoryRepository.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/CategoryRepository.kt
@@ -1,0 +1,8 @@
+package com.team1.mvp_test.domain.mvptest.repository
+
+import com.team1.mvp_test.domain.mvptest.model.Category
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CategoryRepository: JpaRepository<Category, Long> {
+    fun findByName(name: String): Category
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/CategoryRepository.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/CategoryRepository.kt
@@ -4,5 +4,5 @@ import com.team1.mvp_test.domain.mvptest.model.Category
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CategoryRepository: JpaRepository<Category, Long> {
-    fun findByName(name: String): Category
+    fun findByName(name: String): Category?
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/MvpTestRepository.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/MvpTestRepository.kt
@@ -1,0 +1,7 @@
+package com.team1.mvp_test.domain.mvptest.repository
+
+import com.team1.mvp_test.domain.mvptest.model.MvpTest
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MvpTestRepository : JpaRepository<MvpTest, Long>{
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/service/MvpTestService.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/service/MvpTestService.kt
@@ -1,0 +1,12 @@
+package com.team1.mvp_test.domain.mvptest.service
+
+import com.team1.mvp_test.domain.mvptest.repository.MvpTestRepository
+import org.springframework.stereotype.Service
+
+@Service
+class MvpTestService(
+    private val mvpTestRepository: MvpTestRepository
+) {
+    fun createMvpTest(request: CreateMpvTestRequest): MvpTestResponse? {
+    }
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/service/MvpTestService.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/service/MvpTestService.kt
@@ -1,12 +1,102 @@
 package com.team1.mvp_test.domain.mvptest.service
 
+import com.team1.mvp_test.common.error.CategoryErrorMessage
+import com.team1.mvp_test.common.error.EnterpriseErrorMessage
+import com.team1.mvp_test.common.exception.ModelNotFoundException
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.CreateMpvTestRequest
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.MvpTestListResponse
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.MvpTestResponse
+import com.team1.mvp_test.domain.mvptest.dto.mvptest.UpdateMvpTestRequest
+import com.team1.mvp_test.domain.mvptest.model.Category
+import com.team1.mvp_test.domain.mvptest.model.CategoryMap
+import com.team1.mvp_test.domain.mvptest.model.CategoryMapId
+import com.team1.mvp_test.domain.mvptest.repository.CategoryMapRepository
+import com.team1.mvp_test.domain.mvptest.repository.CategoryRepository
 import com.team1.mvp_test.domain.mvptest.repository.MvpTestRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MvpTestService(
-    private val mvpTestRepository: MvpTestRepository
+    private val mvpTestRepository: MvpTestRepository,
+    private val categoryRepository: CategoryRepository,
+    private val categoryMapRepository: CategoryMapRepository
 ) {
-    fun createMvpTest(request: CreateMpvTestRequest): MvpTestResponse? {
+    @Transactional
+    fun createMvpTest(enterpriseId: Long, request: CreateMpvTestRequest): MvpTestResponse {
+        val mvpTest = request.toMvpTest(enterpriseId)
+        mvpTest.state = ""
+        mvpTest.rejectReason = ""
+        val savedMvpTest = mvpTestRepository.save(mvpTest)
+        val categoryMaps = mutableListOf<CategoryMap>()
+        request.category.forEach {
+            //val savedCategory = categoryRepository.save(Category(name = it))
+            val category =
+                try {
+                    categoryRepository.findByName(it)
+                } catch (e: Exception) {
+                    categoryRepository.save(Category(name = it))
+                }
+            categoryMaps.add(
+                categoryMapRepository.save(
+                    CategoryMap(
+                        id = CategoryMapId(categoryId = category.id, mvpTestId = savedMvpTest.id),
+                        category = category
+                    )
+                )
+            )
+        }
+        savedMvpTest.categories = categoryMaps
+        mvpTestRepository.save(savedMvpTest)
+        return MvpTestResponse.from(savedMvpTest)
+    }
+
+    @Transactional
+    fun updateMvpTest(id: Long, testId: Long, request: UpdateMvpTestRequest): MvpTestResponse? {
+        val mvpTest = mvpTestRepository.findByIdOrNull(testId) ?: throw ModelNotFoundException(
+            "MvpTest",
+            testId
+        )
+        checkMvpTestAuthor(id, mvpTest.enterpriseId)
+        val categoryMaps = request.category.map {
+            val category = try {
+                categoryRepository.findByName(it)
+            } catch (e: Exception) {
+                throw IllegalArgumentException(CategoryErrorMessage.DOSE_NOT_EXIST.message)
+            }
+            CategoryMap(id = CategoryMapId(category.id, testId), category)
+        }
+        mvpTest.update(request, categoryMaps)
+        return MvpTestResponse.from(mvpTestRepository.save(mvpTest))
+    }
+
+    fun deleteMvpTest(id: Long, testId: Long) {
+        val mvpTest = mvpTestRepository.findByIdOrNull(testId) ?: throw ModelNotFoundException(
+            "MvpTest",
+            testId
+        )
+        checkMvpTestAuthor(id, mvpTest.enterpriseId)
+        mvpTestRepository.deleteById(testId)
+    }
+
+    fun getMvpTest(testId: Long): MvpTestResponse? {
+        val mvpTest = mvpTestRepository.findByIdOrNull(testId) ?: throw ModelNotFoundException(
+            "MvpTest",
+            testId
+        )
+        return MvpTestResponse.from(mvpTest)
+    }
+
+    fun getMvpTestList(): MvpTestListResponse? {
+        return MvpTestListResponse(mvpTestRepository.findAll().map {
+            MvpTestResponse.from(it)
+        }
+        )
+    }
+
+    private fun checkMvpTestAuthor(enterpriseId: Long, MvpTestAuthorId: Long) {
+        println("enterpriseId : $enterpriseId , mvpAuthorId : $MvpTestAuthorId")
+        check(enterpriseId == MvpTestAuthorId) { EnterpriseErrorMessage.NOT_AUTHORISED.message }
     }
 }


### PR DESCRIPTION
### 개요
mvptest 도메인 기본 CRUD 구현했습니다.
관리자 권한으로만 카테고리를 삽입하는 api 를 따로 만들어야 하나, 테스트 편의상 나중에 구현하려고 합니다.


### 작업사항
- [ ] mvptest 도메인의 기본 CRUD 구현
- [ ] 카테고리와 mvptest 매핑테이블 구현