### PR TITLE
Feat/#38 message verify

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,8 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:5.7.2")
     testImplementation("io.kotest:kotest-assertions-core:5.7.2")
     testImplementation("com.ninja-squad:springmockk:3.0.1")
-
+    implementation("net.nurigo:sdk:4.2.7")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     // Validation
     implementation("org.hibernate.validator:hibernate-validator:8.0.0.Final")
     implementation("jakarta.validation:jakarta.validation-api:3.0.0")

--- a/src/main/kotlin/com/team1/mvp_test/common/error/MemberErrorMessage.kt
+++ b/src/main/kotlin/com/team1/mvp_test/common/error/MemberErrorMessage.kt
@@ -2,4 +2,7 @@ package com.team1.mvp_test.common.error
 
 enum class MemberErrorMessage(val message: String) {
     EMAIL_ALREADY_IN_USE("이미 사용중인 이메일입니다."),
+    PHONENUMBER_ALREADY_EXISTS("이미 사용중인 번호입니다."),
+    PHONENUMBER_VERIFY_FAIL("인증에 실패한 번호입니다."),
+
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/member/dto/SignUpInfoRequest.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/member/dto/SignUpInfoRequest.kt
@@ -1,10 +1,7 @@
 package com.team1.mvp_test.domain.member.dto
 
 import com.team1.mvp_test.domain.member.model.Sex
-import jakarta.validation.constraints.Max
-import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Size
+import jakarta.validation.constraints.*
 
 data class SignUpInfoRequest(
     @field:NotBlank
@@ -15,6 +12,9 @@ data class SignUpInfoRequest(
     val age: Int,
 
     val sex: Sex,
+
+    @field:Pattern(regexp = "^01([0-1])([0-9]{3,4})([0-9]){4}$")
+    val phoneNumber: String,
 
     @field:Size(max = 500)
     val info: String?,

--- a/src/main/kotlin/com/team1/mvp_test/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/member/model/Member.kt
@@ -26,6 +26,9 @@ class Member(
     @Column(name = "info")
     var info: String? = null,
 
+    @Column(name = "phone_number")
+    var phoneNumber: String? = null,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "provider_name")
     val providerName: OAuthProvider? = null,
@@ -41,11 +44,12 @@ class Member(
         this.info = info
     }
 
-    fun updateSignUpInfo(name: String, age: Int, sex: Sex, info: String?) {
+    fun updateSignUpInfo(name: String, age: Int, sex: Sex, info: String?, phoneNumber: String) {
         this.name = name
         this.age = age
         this.sex = sex
         this.info = info
+        this.phoneNumber = phoneNumber
         signUpState = true
     }
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/member/repository/MemberRepository.kt
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByEmail(email: String): Boolean
+    fun existsByPhoneNumber(phoneNumber: String): Boolean
     fun findByProviderIdAndProviderName(providerId: String, providerName: OAuthProvider): Member?
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/member/service/MemberService.kt
@@ -1,5 +1,6 @@
 package com.team1.mvp_test.domain.member.service
 
+import com.team1.mvp_test.common.error.MemberErrorMessage
 import com.team1.mvp_test.common.exception.ModelNotFoundException
 import com.team1.mvp_test.domain.member.dto.MemberResponse
 import com.team1.mvp_test.domain.member.dto.MemberUpdateRequest
@@ -8,22 +9,32 @@ import com.team1.mvp_test.domain.member.dto.SignUpInfoRequest
 import com.team1.mvp_test.domain.member.model.Member
 import com.team1.mvp_test.domain.member.repository.MemberRepository
 import com.team1.mvp_test.domain.oauth.client.OAuthLoginUserInfo
+import com.team1.mvp_test.infra.redis.RedisService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MemberService(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val redisService: RedisService,
 ) {
     @Transactional
     fun updateSignUpInfo(memberId: Long, request: SignUpInfoRequest): MemberResponse {
         val member = memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException("Member", memberId)
+
+        val verifiedPhoneNumber = redisService.getVerifiedPhoneNumber(request.phoneNumber)
+        check(verifiedPhoneNumber != null && verifiedPhoneNumber == request.phoneNumber)
+        { MemberErrorMessage.PHONENUMBER_VERIFY_FAIL }
+        check(!memberRepository.existsByPhoneNumber(request.phoneNumber))
+        { MemberErrorMessage.PHONENUMBER_ALREADY_EXISTS }
+
         member.updateSignUpInfo(
             name = request.name,
             age = request.age,
             sex = request.sex,
-            info = request.info
+            info = request.info,
+            phoneNumber = request.phoneNumber
         )
         return MemberResponse.from(member)
     }

--- a/src/main/kotlin/com/team1/mvp_test/domain/message/controller/MessageController.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/message/controller/MessageController.kt
@@ -1,0 +1,31 @@
+package com.team1.mvp_test.domain.message.controller
+
+import com.team1.mvp_test.domain.message.service.MessageService
+import net.nurigo.sdk.message.response.SingleMessageSentResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/message")
+class MessageController(
+    private val messageService: MessageService
+) {
+    @PostMapping("/send-sms")
+    fun sendSMS(
+        @RequestParam toNumber: String
+    ): ResponseEntity<SingleMessageSentResponse> {
+        return ResponseEntity.status(HttpStatus.OK).body(messageService.sendSMS(toNumber))
+    }
+
+    @PostMapping("/verify-code")
+    fun verifyCode(
+        @RequestParam phoneNumber: String,
+        @RequestParam code: String,
+    ): ResponseEntity<Boolean> {
+        return ResponseEntity.status(HttpStatus.OK).body(messageService.verifyCode(phoneNumber, code))
+    }
+}

--- a/src/main/kotlin/com/team1/mvp_test/domain/message/service/MessageService.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/message/service/MessageService.kt
@@ -1,0 +1,48 @@
+package com.team1.mvp_test.domain.message.service
+
+import com.team1.mvp_test.infra.redis.RedisService
+import net.nurigo.sdk.NurigoApp.initialize
+import net.nurigo.sdk.message.model.Message
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest
+import net.nurigo.sdk.message.response.SingleMessageSentResponse
+import net.nurigo.sdk.message.service.DefaultMessageService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class MessageService(
+    private val redisService: RedisService,
+    @Value("\${coolsms.api.key}") private val messageKey: String,
+    @Value("\${coolsms.api.secret}") private val messageSecret: String,
+    @Value("\${coolsms.api.domain}") private val messageDomain: String,
+    @Value("\${coolsms.fromNumber}") private val fromNumber: String,
+) {
+    val messageService: DefaultMessageService = initialize(messageKey, messageSecret, messageDomain)
+
+    fun sendSMS(
+        toNumber: String
+    ): SingleMessageSentResponse? {
+        val verificationCode = generateVerificationCode()
+        val message = Message(
+            from = fromNumber,
+            to = toNumber,
+            text = "[MVP-TEST] 본인 확인 인증번호는 $verificationCode 입니다."
+        )
+        val response = messageService.sendOne(SingleMessageSendingRequest(message))
+        redisService.saveVerificationCode(toNumber, verificationCode)
+        return response
+    }
+
+    private fun generateVerificationCode(): String {
+        return (100000..999999).random().toString()
+    }
+
+    fun verifyCode(phoneNumber: String, code: String): Boolean {
+        val savedCode = redisService.getVerificationCode(phoneNumber)
+        if (savedCode == code) {
+            redisService.saveVerifiedPhoneNumber(phoneNumber)
+            return true
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/com/team1/mvp_test/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/team1/mvp_test/infra/redis/RedisConfig.kt
@@ -1,0 +1,54 @@
+package com.team1.mvp_test.infra.redis
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisConfig(
+    @Value("\${data.redis.host}") private val redisHost: String,
+    @Value("\${data.redis.port}") private val redisPort: Int,
+) {
+    @Bean
+    fun redisConnectionFactory(): LettuceConnectionFactory {
+        val redisStandaloneConfiguration = RedisStandaloneConfiguration(redisHost, redisPort)
+        val lettuceClientConfiguration = LettuceClientConfiguration.builder()
+            .commandTimeout(Duration.ofSeconds(10))
+            .shutdownTimeout(Duration.ofMillis(100))
+            .build()
+
+        return LettuceConnectionFactory(redisStandaloneConfiguration, lettuceClientConfiguration)
+    }
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, String> {
+        val template = RedisTemplate<String, String>()
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = StringRedisSerializer()
+        template.connectionFactory = redisConnectionFactory()
+        return template
+    }
+
+    @Primary
+    @Bean("redisCacheManager")
+    fun redisCacheManager(): CacheManager {
+        val defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(5))
+
+        return RedisCacheManager.builder(redisConnectionFactory())
+            .cacheDefaults(defaultCacheConfig)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/team1/mvp_test/infra/redis/RedisService.kt
+++ b/src/main/kotlin/com/team1/mvp_test/infra/redis/RedisService.kt
@@ -1,0 +1,37 @@
+package com.team1.mvp_test.infra.redis
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
+
+@Service
+class RedisService(
+    private val redisTemplate: RedisTemplate<String, String>
+) {
+    companion object {
+        private const val VERIFIED_PHONE_PREFIX_ = "verified_"
+        private const val VERIFICATION_CODE_PREFIX = "code_"
+    }
+
+    fun saveVerificationCode(phoneNumber: String, code: String) {
+        val key = VERIFICATION_CODE_PREFIX + phoneNumber
+        redisTemplate.opsForValue()[key] = code
+        redisTemplate.expire(key, 3, TimeUnit.MINUTES)
+    }
+
+    fun getVerificationCode(phoneNumber: String): String? {
+        val key = VERIFICATION_CODE_PREFIX + phoneNumber
+        return redisTemplate.opsForValue()[key]
+    }
+
+    fun saveVerifiedPhoneNumber(phoneNumber: String) {
+        val key = VERIFIED_PHONE_PREFIX_ + phoneNumber
+        redisTemplate.opsForValue()[key] = phoneNumber
+        redisTemplate.expire(key, 10, TimeUnit.MINUTES)
+    }
+
+    fun getVerifiedPhoneNumber(phoneNumber: String): String? {
+        val key = VERIFIED_PHONE_PREFIX_ + phoneNumber
+        return redisTemplate.opsForValue()[key]
+    }
+}

--- a/src/main/kotlin/com/team1/mvp_test/infra/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/team1/mvp_test/infra/security/SecurityConfig.kt
@@ -29,7 +29,8 @@ class SecurityConfig(
                     "/v3/api-docs/**",
                     "api/v1/enterprise/login",
                     "api/v1/enterprise/sign-up",
-                    "/member/oauth/**"
+                    "/member/oauth/**",
+                    "/message/"
                 )
                     .permitAll()
                     .anyRequest().authenticated()

--- a/src/test/kotlin/com/team1/mvp_test/domain/member/dto/MemberDtoTest.kt
+++ b/src/test/kotlin/com/team1/mvp_test/domain/member/dto/MemberDtoTest.kt
@@ -13,7 +13,8 @@ class MemberDtoTest : BehaviorSpec({
             name = "",
             age = 15,
             sex = Sex.MALE,
-            info = null
+            info = null,
+            phoneNumber = "01012345678"
         )
         When("SignUpInfoRequest 검증 시") {
             val violations = validator.validate(request)
@@ -29,7 +30,8 @@ class MemberDtoTest : BehaviorSpec({
             name = "이름",
             age = 10,
             sex = Sex.MALE,
-            info = null
+            info = null,
+            phoneNumber = "01012345678"
         )
         When("SignUpInfoRequest 검증 시") {
             val violations = validator.validate(request)
@@ -45,7 +47,8 @@ class MemberDtoTest : BehaviorSpec({
             name = "이름",
             age = 101,
             sex = Sex.MALE,
-            info = null
+            info = null,
+            phoneNumber = "01012345678"
         )
         When("SignUpInfoRequest 검증 시") {
             val violations = validator.validate(request)
@@ -61,7 +64,8 @@ class MemberDtoTest : BehaviorSpec({
             name = "이름",
             age = 16,
             sex = Sex.MALE,
-            info = "정보입니다".repeat(101)
+            info = "정보입니다".repeat(101),
+            phoneNumber = "01012345678"
         )
         When("SignUpInfoRequest 검증 시") {
             val violations = validator.validate(request)
@@ -77,7 +81,8 @@ class MemberDtoTest : BehaviorSpec({
             name = "이름",
             age = 16,
             sex = Sex.MALE,
-            info = "정보입니다"
+            info = "정보입니다",
+            phoneNumber = "01012345678"
         )
         When("SignUpInfoRequest 검증 시") {
             val violations = validator.validate(request)


### PR DESCRIPTION
## 개요

문자인증 구현(yml 필요)

## 작업사항

- [x]  API 활용해서 문자인증 구현
- [x]  Redis Cache에 `인증번호(3분)`와 UpdateSignUpInfo 제출 시 검증 할 `인증된 전화번호(10분)` 저장
- [x]  이미 사용중인 전화번호 일 경우 Exception 발생

## 관련 이슈

- close #38 