### PR TITLE
Feat/#57 step check reports

### DIFF
--- a/src/main/kotlin/com/team1/mvp_test/domain/member/repository/MemberTestRepository.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/member/repository/MemberTestRepository.kt
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface MemberTestRepository : JpaRepository<MemberTest, Long> {
     fun findByMemberIdAndTestId(memberId: Long, testId: Long): MemberTest?
     fun countByTestIdAndState(testId: Long, state: MemberTestState): Long
-    fun findAllByTestId(testId: Long): List<MemberTest>
+    fun findAllByTestId(testId: Long?): List<MemberTest>
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/report/model/ReportState.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/report/model/ReportState.kt
@@ -1,5 +1,5 @@
 package com.team1.mvp_test.domain.report.model
 
 enum class ReportState {
-    PENDING, REJECTED, APPROVED
+    PENDING, REJECTED, APPROVED, MISSING
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/report/repository/ReportRepository.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/report/repository/ReportRepository.kt
@@ -10,4 +10,5 @@ import org.springframework.stereotype.Repository
 interface ReportRepository : JpaRepository<Report, Long> {
     fun existsByStepAndMemberTest(step: Step, memberTest: MemberTest): Boolean
     fun findAllByMemberTest(memberTest: MemberTest): List<Report>
+    fun findAllByStepId(stepId: Long): List<Report>
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/step/controller/StepController.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/step/controller/StepController.kt
@@ -1,9 +1,6 @@
 package com.team1.mvp_test.domain.step.controller
 
-import com.team1.mvp_test.domain.step.dto.CreateStepRequest
-import com.team1.mvp_test.domain.step.dto.StepListResponse
-import com.team1.mvp_test.domain.step.dto.StepResponse
-import com.team1.mvp_test.domain.step.dto.UpdateStepRequest
+import com.team1.mvp_test.domain.step.dto.*
 import com.team1.mvp_test.domain.step.service.StepService
 import com.team1.mvp_test.infra.security.UserPrincipal
 import jakarta.validation.Valid
@@ -75,6 +72,17 @@ class StepController(
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .body(stepService.deleteStep(userPrincipal.id, stepId))
+    }
+
+    @GetMapping("steps/{stepId}/overview")
+    @PreAuthorize("hasRole('ENTERPRISE')")
+    fun getStepOverview(
+        @PathVariable stepId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ): ResponseEntity<StepOverviewResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(stepService.getStepOverview(userPrincipal.id, stepId))
     }
 
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/step/dto/ReportStatusResponse.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/step/dto/ReportStatusResponse.kt
@@ -1,0 +1,10 @@
+package com.team1.mvp_test.domain.step.dto
+
+import com.team1.mvp_test.domain.report.model.ReportState
+
+
+data class ReportStatusResponse(
+    val memberId: Long,
+    val memberEmail: String,
+    val completionState: ReportState
+)

--- a/src/main/kotlin/com/team1/mvp_test/domain/step/dto/StepOverviewResponse.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/step/dto/StepOverviewResponse.kt
@@ -1,0 +1,6 @@
+package com.team1.mvp_test.domain.step.dto
+
+data class StepOverviewResponse(
+    val completionRate: Int,
+    val reportStatusList: List<ReportStatusResponse>
+)

--- a/src/main/kotlin/com/team1/mvp_test/domain/step/service/StepService.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/step/service/StepService.kt
@@ -4,8 +4,8 @@ import com.team1.mvp_test.common.error.MvpTestErrorMessage
 import com.team1.mvp_test.common.error.StepErrorMessage
 import com.team1.mvp_test.common.exception.ModelNotFoundException
 import com.team1.mvp_test.common.exception.NoPermissionException
-import com.team1.mvp_test.domain.mvptest.model.MvpTestState
 import com.team1.mvp_test.domain.member.repository.MemberTestRepository
+import com.team1.mvp_test.domain.mvptest.model.MvpTestState
 import com.team1.mvp_test.domain.mvptest.repository.MvpTestRepository
 import com.team1.mvp_test.domain.report.model.ReportState
 import com.team1.mvp_test.domain.report.repository.ReportRepository
@@ -22,7 +22,6 @@ import org.springframework.web.multipart.MultipartFile
 class StepService(
     private val stepRepository: StepRepository,
     private val mvpTestRepository: MvpTestRepository,
-    private val s3Service: S3Service,
     private val s3Service: S3Service,
     private val memberTestRepository: MemberTestRepository,
     private val reportRepository: ReportRepository
@@ -99,7 +98,7 @@ class StepService(
         if(enterpriseId != step.mvpTest.enterpriseId)
             throw NoPermissionException(MvpTestErrorMessage.NOT_AUTHORIZED.message)
         //테스트 참여자, 해당 step의 리포트 한꺼번에 불러오기
-        val members = memberTestRepository.findAllByTestId(step.mvpTest.id)
+        val members = memberTestRepository.findAllByTestId(step.mvpTest.id!!)
         val reports = reportRepository.findAllByStepId(stepId)
         //각각의 참여자, 리포트를 memberId로 묶어주고 반환 형태 만들기
         val reportMap = reports.associateBy({ it.memberTest.member.id }, { it.state })

--- a/src/main/kotlin/com/team1/mvp_test/domain/step/service/StepService.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/step/service/StepService.kt
@@ -93,10 +93,10 @@ class StepService(
             ?: throw ModelNotFoundException("Step", stepId)
         if(enterpriseId != step.mvpTest.enterpriseId)
             throw NoPermissionException(MvpTestErrorMessage.NOT_AUTHORIZED.message)
-
+        //테스트 참여자, 해당 step의 리포트 한꺼번에 불러오기
         val members = memberTestRepository.findAllByTestId(step.mvpTest.id)
         val reports = reportRepository.findAllByStepId(stepId)
-
+        //각각의 참여자, 리포트를 memberId로 묶어주고 반환 형태 만들기
         val reportMap = reports.associateBy({ it.memberTest.member.id }, { it.state })
         val reportStatusResponse = members.map { memberTest ->
             val reportState = reportMap[memberTest.member.id] ?: ReportState.MISSING
@@ -106,6 +106,7 @@ class StepService(
                 completionState = reportState
             )
         }
+        //참여율 백분율로 계산
         val approvedCount = reportStatusResponse.count { it.completionState == ReportState.APPROVED }
         val totalCount = reportStatusResponse.size
         val completionRate = if (totalCount > 0) {

--- a/src/test/kotlin/com/team1/mvp_test/domain/step/service/StepServiceTest.kt
+++ b/src/test/kotlin/com/team1/mvp_test/domain/step/service/StepServiceTest.kt
@@ -3,10 +3,12 @@ package com.team1.mvp_test.domain.step.service
 import com.team1.mvp_test.common.exception.ModelNotFoundException
 import com.team1.mvp_test.common.exception.NoPermissionException
 import com.team1.mvp_test.domain.member.model.Sex
+import com.team1.mvp_test.domain.member.repository.MemberTestRepository
 import com.team1.mvp_test.domain.mvptest.model.MvpTest
 import com.team1.mvp_test.domain.mvptest.model.MvpTestState
 import com.team1.mvp_test.domain.mvptest.model.RecruitType
 import com.team1.mvp_test.domain.mvptest.repository.MvpTestRepository
+import com.team1.mvp_test.domain.report.repository.ReportRepository
 import com.team1.mvp_test.domain.step.dto.CreateStepRequest
 import com.team1.mvp_test.domain.step.dto.UpdateStepRequest
 import com.team1.mvp_test.domain.step.model.Step
@@ -14,7 +16,8 @@ import com.team1.mvp_test.domain.step.repository.StepRepository
 import com.team1.mvp_test.infra.s3.s3service.S3Service
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.mock.web.MockMultipartFile
 import java.time.LocalDateTime
@@ -24,11 +27,15 @@ class StepServiceTest : BehaviorSpec({
 
     val stepRepository = mockk<StepRepository>()
     val mvpTestRepository = mockk<MvpTestRepository>()
+    val memberTestRepository = mockk<MemberTestRepository>()
+    val reportRepository = mockk<ReportRepository>()
     val s3Service = mockk<S3Service>()
     val stepService = StepService(
         stepRepository = stepRepository,
         mvpTestRepository = mvpTestRepository,
-        s3Service = s3Service
+        s3Service = s3Service,
+        memberTestRepository = memberTestRepository,
+        reportRepository = reportRepository,
     )
     Given("createStep 실행 시"){
         every { mvpTestRepository.findByIdOrNull(TEST_ID) } returns mvpTest


### PR DESCRIPTION
## 개요

특정 STEP에 대한 모든 참가자의 진행 여부를 파악하는 api 추가

## 작업사항

- [x]  특정 step 에 해당하는 api 작성
- [x]  해당 step 의 test 를 작성한 enterprise 만 접근할 수 있도록 설정
- [x]  해당 test의 참가자들이 선택한 step의 roport를 얼마나 작성했는지 확인
- [x]  작성한 report 들을 반환
- [ ]  해당 로직의 test 코드

## 관련 이슈

- #57 

## 추가 메시지

일단 중간 제출이 바로 앞이라 구현과 swagger 테스트만 하고 PR 올립니다
이슈 닫지 않고 같은 브렌치에서 테스트코드와 쿼리 최적화 진행할 예정입니다