### PR TITLE
Feat/#61 mvpTest domain API Implement

### DIFF
--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
@@ -94,7 +94,7 @@ class MvpTestController(
         return mvpTestService.getMemberList(testId, enterpriseId)
     }
 
-    @GetMapping("/{testId}/enterprise")
+    @GetMapping("/enterprise")
     @PreAuthorize("hasRole('ENTERPRISE')")
     fun getMvpTestsByEnterprise(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/controller/MvpTestController.kt
@@ -1,6 +1,7 @@
 package com.team1.mvp_test.domain.mvptest.controller
 
 import com.team1.mvp_test.domain.mvptest.dto.CreateMvpTestRequest
+import com.team1.mvp_test.domain.mvptest.dto.MemberInfoResponse
 import com.team1.mvp_test.domain.mvptest.dto.MvpTestResponse
 import com.team1.mvp_test.domain.mvptest.dto.UpdateMvpTestRequest
 import com.team1.mvp_test.domain.mvptest.service.MvpTestService
@@ -81,5 +82,24 @@ class MvpTestController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(mvpTestService.applyToMvpTest(userPrincipal.id, testId))
+    }
+
+    @GetMapping("/{testId}/member")
+    @PreAuthorize("hasRole('ENTERPRISE')")
+    fun getTestMemberList(
+        @PathVariable("testId") testId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+    ): List<MemberInfoResponse> {
+        val enterpriseId = userPrincipal.id
+        return mvpTestService.getMemberList(testId, enterpriseId)
+    }
+
+    @GetMapping("/{testId}/enterprise")
+    @PreAuthorize("hasRole('ENTERPRISE')")
+    fun getMvpTestsByEnterprise(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+    ): List<MvpTestResponse> {
+        val enterpriseId = userPrincipal.id
+        return mvpTestService.getMvpTestsByEnterprise(enterpriseId)
     }
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/MemberInfoResponse.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/dto/MemberInfoResponse.kt
@@ -1,0 +1,8 @@
+package com.team1.mvp_test.domain.mvptest.dto
+
+data class MemberInfoResponse(
+    val memberId: Long,
+    val email: String,
+    val phoneNumber: String,
+    val name: String,
+)

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/MvpTestRepository.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/repository/MvpTestRepository.kt
@@ -1,7 +1,12 @@
 package com.team1.mvp_test.domain.mvptest.repository
 
 import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.team1.mvp_test.domain.member.model.MemberTestState
+import com.team1.mvp_test.domain.member.model.QMember
+import com.team1.mvp_test.domain.member.model.QMemberTest
+import com.team1.mvp_test.domain.mvptest.dto.MemberInfoResponse
 import com.team1.mvp_test.domain.mvptest.model.MvpTest
 import com.team1.mvp_test.domain.mvptest.model.QMvpTest
 import org.springframework.data.jpa.repository.JpaRepository
@@ -10,10 +15,12 @@ import java.time.LocalDateTime
 
 @Repository
 interface MvpTestRepository : JpaRepository<MvpTest, Long>, MvpTestQueryDslRepository {
+    fun findAllByEnterpriseId(enterpriseId: Long): List<MvpTest>
 }
 
 interface MvpTestQueryDslRepository {
     fun findAllUnsettledMvpTests(todayDate: LocalDateTime): List<MvpTest>
+    fun findMemberList(testId: Long, enterpriseId: Long): List<MemberInfoResponse>
 }
 
 class MvpTestQueryDslRepositoryImpl(
@@ -21,6 +28,9 @@ class MvpTestQueryDslRepositoryImpl(
 ) : MvpTestQueryDslRepository {
 
     private val mvpTest: QMvpTest = QMvpTest.mvpTest
+    private val memberTest: QMemberTest = QMemberTest.memberTest
+    private val member: QMember = QMember.member
+
     override fun findAllUnsettledMvpTests(todayDate: LocalDateTime): List<MvpTest> {
         val builder = BooleanBuilder()
             .and(mvpTest.testEndDate.before(todayDate))
@@ -28,6 +38,26 @@ class MvpTestQueryDslRepositoryImpl(
         return queryFactory.selectFrom(mvpTest)
             .where(builder)
             .fetch()
+    }
 
+    override fun findMemberList(testId: Long, enterpriseId: Long): List<MemberInfoResponse> {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    MemberInfoResponse::class.java,
+                    member.id,
+                    member.email,
+                    member.phoneNumber,
+                    member.name,
+                )
+            )
+            .from(memberTest)
+            .join(memberTest.member, member)
+            .where(
+                memberTest.test.id.eq(testId)
+                    .and(memberTest.test.enterpriseId.eq(enterpriseId))
+                    .and(memberTest.state.eq(MemberTestState.APPROVED))
+            )
+            .fetch()
     }
 }

--- a/src/main/kotlin/com/team1/mvp_test/domain/mvptest/service/MvpTestService.kt
+++ b/src/main/kotlin/com/team1/mvp_test/domain/mvptest/service/MvpTestService.kt
@@ -15,6 +15,7 @@ import com.team1.mvp_test.domain.member.repository.MemberRepository
 import com.team1.mvp_test.domain.member.repository.MemberTestRepository
 import com.team1.mvp_test.domain.member.service.MemberService
 import com.team1.mvp_test.domain.mvptest.dto.CreateMvpTestRequest
+import com.team1.mvp_test.domain.mvptest.dto.MemberInfoResponse
 import com.team1.mvp_test.domain.mvptest.dto.MvpTestResponse
 import com.team1.mvp_test.domain.mvptest.dto.UpdateMvpTestRequest
 import com.team1.mvp_test.domain.mvptest.model.MvpTest
@@ -166,6 +167,19 @@ class MvpTestService(
                 test = test,
                 state = MemberTestState.PENDING
             ).let { memberTestRepository.save(it) }
+        }
+    }
+
+    fun getMemberList(testId: Long, enterpriseId: Long): List<MemberInfoResponse> {
+        return mvpTestRepository.findMemberList(testId, enterpriseId)
+    }
+
+    fun getMvpTestsByEnterprise(enterpriseId: Long): List<MvpTestResponse> {
+        val test = mvpTestRepository.findAllByEnterpriseId(enterpriseId)
+
+        return test.map { mvpTest ->
+            val categories = mvpTestCategoryMapRepository.findAllByMvpTestId(mvpTest.id!!).map { it.category.name }
+            MvpTestResponse.from(mvpTest, categories)
         }
     }
 


### PR DESCRIPTION
## 개요

mvptest domain api 추가

## 작업사항

- [x] enterprise 입장에서 자신이 쓴 mvptest 전체 반환
- [x] enterprise 입장에서 자신이 쓴 mvptest의 참여자 List 반환

## 관련 이슈

- close #61 